### PR TITLE
Always accept build scans

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,14 @@
+plugins {
+  id "com.gradle.enterprise" version "3.12.6"
+}
+
+gradleEnterprise {
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+  }
+}
+
 rootProject.name = 'paparazzi-root'
 
 include ':sample'


### PR DESCRIPTION
My first change in this fork.

Notice we'll use the `mercari` branch as trunk so we can automatically keep updating master with upstream,
as they're doing in https://github.com/mercari/tulsi

Also it's just about accepting build scans, but it's not emitting them for each edit.
You can read [CI logs](https://github.com/mercari/paparazzi/actions/runs/4540411626/jobs/8001299941?pr=1) to see no build scan was created by default.

See https://docs.gradle.com/enterprise/gradle-plugin/#connecting_to_scans_gradle_com for more details.